### PR TITLE
Update global definitions file with constants and replaced magic numbers in code

### DIFF
--- a/src/dpmproject/GlobalDefinitions.java
+++ b/src/dpmproject/GlobalDefinitions.java
@@ -3,11 +3,35 @@ package dpmproject;
  * 
  */
 
+import lejos.hardware.motor.EV3LargeRegulatedMotor;
+import lejos.hardware.motor.UnregulatedMotor;
+import lejos.robotics.SampleProvider;
+
 /**
  * @author Ali
  *
  */
 public final class GlobalDefinitions {
-	//TODO fill with global definitions used by other classes like Odometer.java
+	
+  public static final double WHEEL_RADIUS                     = 2.1;  // In centimeters
+  public static final double WHEEL_BASE                       = 15.0; // In centimeters
+  public static final double LIGHT_SENSOR_OFFSET              = 12.0; // In centimeters
+  public static final double DEG_ERR                          = 2.0;  // In degrees
+  public static final double LIN_ERR                          = 1.0;  // In centimeters
+  public static final double ACCELERATION                     = 4000; // In degrees per second per second
+  public static final double FORWARD_SPEED                    = 75.0; // In degrees per second
+  public static final double TURN_SPEED                       = 50.0; // In degrees per second
+
+  public static final int SWING_TIME                          = 500;  // In milliseconds
+
+
+  // TODO fill in sensor and motor initialization
+  /*
+  public static final EV3LargeRegulatedMotor LEFT_MOTOR;
+  public static final EV3LargeRegulatedMotor RIGHT_MOTOR;
+  public static final UnregulatedMotor LAUNCHER_MOTOR;
+  public static final SampleProvider LIGHT_SENSOR;
+  public static final SampleProvider US_SENSOR;
+  */
 
 }

--- a/src/dpmproject/GlobalDefinitions.java
+++ b/src/dpmproject/GlobalDefinitions.java
@@ -3,9 +3,11 @@ package dpmproject;
  * 
  */
 
+import lejos.hardware.ev3.LocalEV3;
 import lejos.hardware.motor.EV3LargeRegulatedMotor;
 import lejos.hardware.motor.UnregulatedMotor;
-import lejos.robotics.SampleProvider;
+import lejos.hardware.sensor.EV3ColorSensor;
+import lejos.hardware.sensor.EV3UltrasonicSensor;
 
 /**
  * @author Ali
@@ -23,15 +25,17 @@ public final class GlobalDefinitions {
   public static final double TURN_SPEED                       = 50.0; // In degrees per second
 
   public static final int SWING_TIME                          = 500;  // In milliseconds
+  
+  private static final String leftMotorPort                   = "A";
+  private static final String rightMotorPort                  = "D";
+  private static final String launcherMotorPort               = "C";
+  private static final String lightSensorPort                 = "1";
+  private static final String usSensorPort                    = "3";
 
-
-  // TODO fill in sensor and motor initialization
-  /*
-  public static final EV3LargeRegulatedMotor LEFT_MOTOR;
-  public static final EV3LargeRegulatedMotor RIGHT_MOTOR;
-  public static final UnregulatedMotor LAUNCHER_MOTOR;
-  public static final SampleProvider LIGHT_SENSOR;
-  public static final SampleProvider US_SENSOR;
-  */
+  public static final EV3LargeRegulatedMotor LEFT_MOTOR       = new EV3LargeRegulatedMotor(LocalEV3.get().getPort(leftMotorPort));
+  public static final EV3LargeRegulatedMotor RIGHT_MOTOR      = new EV3LargeRegulatedMotor(LocalEV3.get().getPort(rightMotorPort));
+  public static final UnregulatedMotor LAUNCHER_MOTOR         = new UnregulatedMotor(LocalEV3.get().getPort(launcherMotorPort));
+  public static final EV3ColorSensor LIGHT_SENSOR             = new EV3ColorSensor(LocalEV3.get().getPort(lightSensorPort));
+  public static final EV3UltrasonicSensor US_SENSOR           = new EV3UltrasonicSensor(LocalEV3.get().getPort(usSensorPort));
 
 }

--- a/src/dpmproject/LightLocalizer.java
+++ b/src/dpmproject/LightLocalizer.java
@@ -10,8 +10,8 @@ public class LightLocalizer {
 	private SampleProvider colorSensor;
 	private float[] colorData;	
 	
-	public static final float ROTATION_SPEED = 100;
-	public static final double COLOR_SENSOR_OFFSET = 14;	// Distance between center of rotation and the color sensor in cm
+	public static final float ROTATION_SPEED = (float) GlobalDefinitions.TURN_SPEED;
+	public static final double COLOR_SENSOR_OFFSET = GlobalDefinitions.LIGHT_SENSOR_OFFSET;	// Distance between center of rotation and the color sensor in cm
 	private static final double BLACK_RGB = 0.2;
 	private static final int AXIS_CROSS_DELAY = 200, SENSOR_POLL_PERIOD = 10;
 	

--- a/src/dpmproject/Navigation.java
+++ b/src/dpmproject/Navigation.java
@@ -12,7 +12,7 @@ package dpmproject;
 import lejos.hardware.motor.EV3LargeRegulatedMotor;
 
 public class Navigation {
-	final static int FAST = 50, SLOW = 25, ACCELERATION = 4000;
+	final static int FAST = (int) GlobalDefinitions.FORWARD_SPEED, SLOW = (int) GlobalDefinitions.TURN_SPEED, ACCELERATION = (int) GlobalDefinitions.ACCELERATION;
 	final static double DEG_ERR = 1.0, CM_ERR = 1.0;
 	private Odometer odometer;
 	private EV3LargeRegulatedMotor leftMotor, rightMotor;

--- a/src/dpmproject/Odometer.java
+++ b/src/dpmproject/Odometer.java
@@ -48,9 +48,9 @@ public class Odometer implements TimerListener, OdometerInterface {
 		this.rightMotor = rightMotor;
 		
 		// default values, modify for your robot
-		this.rightRadius = 2.1;
-		this.leftRadius = 2.1;
-		this.width = 15.0;
+		this.rightRadius = GlobalDefinitions.WHEEL_RADIUS;
+		this.leftRadius = GlobalDefinitions.WHEEL_RADIUS;
+		this.width = GlobalDefinitions.WHEEL_BASE;
 		
 		this.x = 0.0;
 		this.y = 0.0;

--- a/src/dpmproject/USLocalizer.java
+++ b/src/dpmproject/USLocalizer.java
@@ -7,7 +7,7 @@ import lejos.utility.Delay;
 public class USLocalizer {
 	public enum LocalizationType { FALLING_EDGE, RISING_EDGE }
 	
-	private final float ROTATION_SPEED = 100;
+	private final float ROTATION_SPEED = (float) GlobalDefinitions.TURN_SPEED;
 	private final int MIN_WALL_DIST = 45;
 	private int filterControl = 0;
 	private final int FILTER_OUT = 20;


### PR DESCRIPTION
The magic number present in the odometer, navigation, and localization classes have been removed and replaced with the constants from globaldefinitions.java

However, the motor variables haven't been touched yet. Also we might need to adjust the sensor constants to point to sensor threads. Depends on what we want. I will look into this some more.